### PR TITLE
Updated Score readme based on feedback

### DIFF
--- a/.github/workflows/linkchecker.yaml
+++ b/.github/workflows/linkchecker.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@v1.10.0
         with:
-          args: --exclude https://meet.google.com
+          args: --verbose --no-progress '\''./**/*.md'\'' '\''./**/*.html'\'' --exclude https://meet.google.com
           fail: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/linkchecker.yaml
+++ b/.github/workflows/linkchecker.yaml
@@ -13,6 +13,7 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@v1.10.0
         with:
+          args: "--exclude meet\.google\.com"
           fail: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/linkchecker.yaml
+++ b/.github/workflows/linkchecker.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Link Checker
-        uses: lycheeverse/lychee-action@v1.5.0
+        uses: lycheeverse/lychee-action@v1.10.0
         with:
           fail: true
         env:

--- a/.github/workflows/linkchecker.yaml
+++ b/.github/workflows/linkchecker.yaml
@@ -13,6 +13,7 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@v1.10.0
         with:
+          # Providing default parameters plus an exclude for Google Meet which produces a network error when checked
           args: --verbose --no-progress './**/*.md' './**/*.html' --exclude https://meet.google.com
           fail: true
         env:

--- a/.github/workflows/linkchecker.yaml
+++ b/.github/workflows/linkchecker.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@v1.10.0
         with:
-          args: "--exclude meet\.google\.com"
+          args: --exclude https://meet.google.com
           fail: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/linkchecker.yaml
+++ b/.github/workflows/linkchecker.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@v1.10.0
         with:
-          args: --verbose --no-progress '\''./**/*.md'\'' '\''./**/*.html'\'' --exclude https://meet.google.com
+          args: --verbose --no-progress './**/*.md' './**/*.html' --exclude https://meet.google.com
           fail: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
We continue to receive feedback on the separation of score specification vs implementation not being quite clear. This PR aims to more transparently differentiate between both i.e.  that the core component of Score is the specification while the it is intended that people adopt the spec and build their own implementations.