### PR TITLE
feat: allow dot as separator in resource id

### DIFF
--- a/samples/score-full.yaml
+++ b/samples/score-full.yaml
@@ -70,6 +70,6 @@ resources:
         data: here
   resource-two2:
     type: Resource-Two
-  resource-three:
+  resource.three:
     type: Type-Three
     id: shared-type-three

--- a/score-v1b1.json
+++ b/score-v1b1.json
@@ -144,11 +144,11 @@
           "pattern": "^[A-Za-z0-9][A-Za-z0-9-]{0,61}[A-Za-z0-9]$"
         },
         "id": {
-          "description": "An optional external Resource identifier. When two resources share the same type, class, and id, they are considered the same resource when used across related Workloads. The id must be a valid RFC1123 Label Name of up to 63 characters, including a-z, 0-9, '-' but may not start or end with '-'.",
+          "description": "An optional Resource identifier. When two resources share the same type, class, and id, they are considered the same resource when used across related Workloads. The id may be up to 63 characters, including a-z, 0-9, '-' or '.' but may not start or end with '-' or '.'.",
           "type": "string",
           "minLength": 2,
           "maxLength": 63,
-          "pattern": "^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$"
+          "pattern": "^[a-z0-9][a-z0-9-.]{0,61}[a-z0-9]$"
         },
         "metadata": {
           "description": "The metadata for the Resource.",

--- a/score-v1b1.json
+++ b/score-v1b1.json
@@ -144,11 +144,11 @@
           "pattern": "^[A-Za-z0-9][A-Za-z0-9-]{0,61}[A-Za-z0-9]$"
         },
         "id": {
-          "description": "An optional Resource identifier. When two resources share the same type, class, and id, they are considered the same resource when used across related Workloads. The id may be up to 63 characters, including a-z, 0-9, '-' or '.' but may not start or end with '-' or '.'.",
+          "description": "An optional Resource identifier. The id may be up to 63 characters, including one or more labels of a-z, 0-9, '-' not starting or ending with '-' separated by '.'. When two resources share the same type, class, and id, they are considered the same resource when used across related Workloads.",
           "type": "string",
           "minLength": 2,
           "maxLength": 63,
-          "pattern": "^[a-z0-9][a-z0-9-.]{0,61}[a-z0-9]$"
+          "pattern": "^[a-z0-9]+(?:-+[a-z0-9]+)*(?:\\.[a-z0-9]+(?:-+[a-z0-9]+)*)*$"
         },
         "metadata": {
           "description": "The metadata for the Resource.",


### PR DESCRIPTION
This PR relates to the resource `id` field in a spec like the following (marked by the arrow below):

```yaml
apiVersion: score.dev/v1b1
metadata:
  name: example-workload
service:
  ports:
    http:
      port: 8080
...
resources:
  something:
    type: resource-type
    class: default
    id: custom-type              <-----
```

Currently, this field supports the same character set and syntax as other fields like the workload name, resource type, resource class, etc. In this PR we'd like to change it to also support `.` as a separator character in order to support resource provisioners that need relate a resource id to a workload.

The example usecase is when we want a resource id to be related to a workload in some way, for example, for example: `example-workload.thing` would be an identifier for a 'thing' relative to the 'example-workload' workload.

**Alternatives**

One alternative is to use the resource type, resource class, or a param to indicate this relation to the resource provisioner.

Resource class is not adequate here, because class is a useful provisioner differentiator: the same 'thing' relation could be returned by different classes with different behaviors over the same relation.

Resource param is not adequate here, because the provisioner that provides id: example-workload.thing may not be capable of handling example-workload.other-thing.

Resource type is not adequate here either because the output type structure of the 'thing' is the same for workload-a and workload-b.

Thus it's most natural to encode this as an id.

**Shared resources**

This also works well in the case of 2 workloads that want to refer to the same 'thing' relation on the example-workload.

```mermaid
flowchart LR
  A[workload-a] --> R("`type: res-type
class: default
id: shared.workload-c.thing`")
  B[workload-b] --> R
  subgraph workload-c
    thing
  end
  R --> thing
```