### PR TITLE
feat: allow valid Score specs without a containers section and support top level extensions

### DIFF
--- a/samples/score-minimal.yaml
+++ b/samples/score-minimal.yaml
@@ -1,0 +1,3 @@
+apiVersion: score.dev/v1b1
+metadata:
+  name: example-workload-name123

--- a/samples/score-with-extensions.yaml
+++ b/samples/score-with-extensions.yaml
@@ -1,0 +1,10 @@
+apiVersion: score.dev/v1b1
+metadata:
+  name: example-workload-name123
+x-my-extension:
+  archive: http://example.com/binary.tgz
+  variables:
+    SOME_VAR: ${resources.example.thing}
+resources:
+  example:
+    type: resource-type

--- a/score-v1b1.json
+++ b/score-v1b1.json
@@ -6,10 +6,16 @@
   "type": "object",
   "required": [
     "apiVersion",
-    "metadata",
-    "containers"
+    "metadata"
   ],
   "additionalProperties": false,
+  "patternProperties": {
+    "^x-.+": {
+      "description": "A top-level Score extention. This is a schema extension which is not defined by the common Score specification but may be supported by a subset of Score implementations. The 'x-' prefix avoid conflict with future top level fields in the Score specification.",
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
   "properties": {
     "apiVersion": {
       "description": "The declared Score Specification version.",
@@ -67,7 +73,7 @@
     "containers": {
       "description": "The set of named containers in the Workload. The container name must be a valid RFC1123 Label Name of up to 63 characters, including a-z, 0-9, '-' but may not start or end with '-'.",
       "type": "object",
-      "minProperties": 0,
+      "minProperties": 1,
       "additionalProperties": {
         "$ref": "#/$defs/container"
       },

--- a/score-v1b1.json
+++ b/score-v1b1.json
@@ -67,7 +67,7 @@
     "containers": {
       "description": "The set of named containers in the Workload. The container name must be a valid RFC1123 Label Name of up to 63 characters, including a-z, 0-9, '-' but may not start or end with '-'.",
       "type": "object",
-      "minProperties": 1,
+      "minProperties": 0,
       "additionalProperties": {
         "$ref": "#/$defs/container"
       },


### PR DESCRIPTION
We've been looking at how we can use Score to support slightly more abstract workloads and we've seen that the > 1 `containers` places somewhat of a limitation on what Score implementations can accept and transform and how teams can iterate and learn about Score. This coincides with the need to start supporting additional top level extensions on the spec:

```
apiVersion: score.dev/v1b1
metadata:
  name: example-workload-name123
x-my-extension:
  archive: http://example.com/binary.tgz
  variables:
    SOME_VAR: ${resources.example.thing}
resources:
  example:
    type: resource-type
```