### PR TITLE
chore: attach score schema file to release artefacts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,16 @@
+name: Release
+on:
+  release:
+    types: [created]
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Release
+      uses: softprops/action-gh-release@v2
+      permissions:
+        contents: write
+      with:
+        files: |
+          score-v1b1.json


### PR DESCRIPTION
As discussed in #116 meeting part 2, we want to start tagging actual semver releases on this repo and attach the schema file as an "artefact". 

This PR does this using the release trigger and the step that can upload to an existing release based on its tag.

