### PR TITLE
feat: support binaryContent for inline Score files

### DIFF
--- a/samples/score-full.yaml
+++ b/samples/score-full.yaml
@@ -34,6 +34,8 @@ containers:
       content: |
         some multiline
         content
+    - target: /my/other/binaryfile
+      binaryContent: ADBgwpA=
     volumes:
     - source: volume-name
       target: /mnt/something

--- a/score-v1b1.json
+++ b/score-v1b1.json
@@ -235,6 +235,7 @@
           "description": "The extra files to mount into the container.",
           "type": "array",
           "items": {
+            "description": "The details of a file to mount in the container. One of 'source', 'content', or 'binaryContent' must be provided.",
             "type": "object",
             "required": [
               "target"
@@ -257,7 +258,11 @@
                 "minLength": 1
               },
               "content": {
-                "description": "The inline content for the file.",
+                "description": "The inline content for the file. Only supports valid utf-8.",
+                "type": "string"
+              },
+              "binaryContent": {
+                "description": "Inline standard-base64 encoded content for the file. Does not support placeholder expansion.",
                 "type": "string"
               },
               "noExpand": {
@@ -270,6 +275,12 @@
                 "required": [
                   "target",
                   "content"
+                ]
+              },
+              {
+                "required": [
+                  "target",
+                  "binaryContent"
                 ]
               },
               {


### PR DESCRIPTION
I've been investigating a long standing issue of dealing with non-utf-8 files when normalising a score spec. Normally when we 'normalise' the spec, we convert any files specified via `source` into inline files with `content`. However, since the score file itself is utf-8, not any old binary content can be written as valid unicode into the yaml file. It breaks if any non-utf-8 sequences are used, and the user will be left wondering why their file contains magic `\xEF\xBF\xBD` bytes instead.

I think the solution is instead to allow a separate `binaryContent` field which clearly contains base64. This is similar to kubernetes config maps which contain a `binaryData` section alongside the `data` section and allows for better validation routines and checking in the implementation.

An example score file might look like:

```
$ openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -sha256 -days 365
$ openssl x509 -in cert.pem -out cert.der -outform der
$ cat score.yaml
apiVersion: score.dev/v1b1
metadata:
  name: example
containers:
  main:
    image: debian
    args:
    - sleep
    - infinity
    files:
    - target: /mnt/cert.der
      source: ./cert.der
```

This will be supported without trouble in `score-compose` and `score-k8s`, and Humanitec may implement an extension to their existing "variables" with a similar base64 marker or alternative.