### PR TITLE
feat: support map of files and volumes and mark arrays as deprecated

### DIFF
--- a/samples/score-deprecated-files-and-volumes.yaml
+++ b/samples/score-deprecated-files-and-volumes.yaml
@@ -1,0 +1,16 @@
+# The following workload describes a container which has a file and volume mounted. The file mount is using the deprecated format of an array of files.
+# This was deprecated since files do not infer order and the "target" path can be considered both required and unique. Simalarly, the volume mount is also
+# using a deprecated array format.
+# ==========================================================================================================================================
+apiVersion: score.dev/v1b1
+metadata:
+  name: "deprecated-files-example"
+containers:
+  main:
+    image: "example-image:latest"
+    files:
+    - target: /mnt/some-path
+      content: "my content here"
+    volumes:
+    - target: /mnt/vol
+      source: some-volume

--- a/samples/score-full.yaml
+++ b/samples/score-full.yaml
@@ -27,22 +27,22 @@ containers:
     variables:
       SOME_VAR: some content here
     files:
-    - target: /my/file
-      mode: "0600"
-      source: file.txt
-    - target: /my/other/file
-      content: |
-        some multiline
-        content
-    - target: /my/other/binaryfile
-      binaryContent: ADBgwpA=
+      /my/file:
+        mode: "0600"
+        source: file.txt
+      /my/other/file:
+        content: |
+          some multiline
+          content
+      /my/other/binaryfile:
+        binaryContent: ADBgwpA=
     volumes:
-    - source: volume-name
-      target: /mnt/something
-      path: /sub/path
-      readOnly: false
-    - source: volume-two
-      target: /mnt/something-else
+      /mnt/something:
+        source: volume-name
+        path: /sub/path
+        readOnly: false
+      /mnt/something-else:
+        source: volume-two
     livenessProbe:
       httpGet:
         port: 8080

--- a/score-v1b1.json
+++ b/score-v1b1.json
@@ -193,6 +193,84 @@
         }
       }
     },
+    "containerFile": {
+      "description": "The details of a file to mount in the container. One of 'source', 'content', or 'binaryContent' must be provided.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "target": {
+          "description": "(Deprecated) The file path to expose in the container. This is only used in Score workloads that describe files as an array.",
+          "deprecated": true,
+          "type": "string",
+          "minLength": 1
+        },
+        "mode": {
+          "description": "The optional file access mode in octal encoding. For example 0600.",
+          "type": "string",
+          "pattern": "^0?[0-7]{3}$"
+        },
+        "source": {
+          "description": "The relative or absolute path to the content file.",
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "description": "The inline content for the file. Only supports valid utf-8.",
+          "type": "string"
+        },
+        "binaryContent": {
+          "description": "Inline standard-base64 encoded content for the file. Does not support placeholder expansion.",
+          "type": "string"
+        },
+        "noExpand": {
+          "description": "If set to true, the placeholders expansion will not occur in the contents of the file.",
+          "type": "boolean"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "content"
+          ]
+        },
+        {
+          "required": [
+            "binaryContent"
+          ]
+        },
+        {
+          "required": [
+            "source"
+          ]
+        }
+      ]
+    },
+    "containerVolume": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source"
+      ],
+      "properties": {
+        "source": {
+          "description": "The external volume reference.",
+          "type": "string"
+        },
+        "path": {
+          "description": "An optional sub path in the volume.",
+          "type": "string"
+        },
+        "target": {
+          "description": "(Deprecated) The target mount on the container. This is only used in Score workloads that describe volumes as an array.",
+          "deprecated": true,
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "Indicates if the volume should be mounted in a read-only mode.",
+          "type": "boolean"
+        }
+      }
+    },
     "container": {
       "description": "The specification of a Container within the Workload.",
       "type": "object",
@@ -232,95 +310,40 @@
           }
         },
         "files": {
-          "description": "The extra files to mount into the container.",
-          "type": "array",
-          "items": {
-            "description": "The details of a file to mount in the container. One of 'source', 'content', or 'binaryContent' must be provided.",
-            "type": "object",
-            "required": [
-              "target"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "target": {
-                "description": "The file path to expose in the container.",
-                "type": "string",
-                "minLength": 1
-              },
-              "mode": {
-                "description": "The optional file access mode in octal encoding. For example 0600.",
-                "type": "string",
-                "pattern": "^0?[0-7]{3}$"
-              },
-              "source": {
-                "description": "The relative or absolute path to the content file.",
-                "type": "string",
-                "minLength": 1
-              },
-              "content": {
-                "description": "The inline content for the file. Only supports valid utf-8.",
-                "type": "string"
-              },
-              "binaryContent": {
-                "description": "Inline standard-base64 encoded content for the file. Does not support placeholder expansion.",
-                "type": "string"
-              },
-              "noExpand": {
-                "description": "If set to true, the placeholders expansion will not occur in the contents of the file.",
-                "type": "boolean"
+          "description": "The extra files to mount into the container. Described as a map of target paths to file details. The array form is deprecated.", 
+          "oneOf": [
+            {
+              "type": "array",
+              "deprecated": true,
+              "items": {
+                "$ref": "#/$defs/containerFile"
               }
             },
-            "oneOf": [
-              {
-                "required": [
-                  "target",
-                  "content"
-                ]
-              },
-              {
-                "required": [
-                  "target",
-                  "binaryContent"
-                ]
-              },
-              {
-                "required": [
-                  "target",
-                  "source"
-                ]
-              }
-            ]
-          }
-        },
-        "volumes": {
-          "description": "The volumes to mount.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "required": [
-              "source",
-              "target"
-            ],
-            "properties": {
-              "source": {
-                "description": "The external volume reference.",
-                "type": "string"
-              },
-              "path": {
-                "description": "An optional sub path in the volume.",
-                "type": "string"
-              },
-              "target": {
-                "description": "The target mount on the container.",
-                "type": "string"
-              },
-              "readOnly": {
-                "description": "Indicates if the volume should be mounted in a read-only mode.",
-                "type": "boolean"
+            {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/containerFile"
               }
             }
-          }
+          ]
+        },
+        "volumes": {
+          "description": "The volumes to mount. Described as a map of target paths to volume details. The array form is deprecated.",
+          "oneOf": [
+            {
+              "type": "array",
+              "deprecated": true,
+              "items": {
+                "$ref": "#/$defs/containerVolume"
+              }
+            },
+            {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/containerVolume"
+              }
+            }
+          ]
         },
         "resources": {
           "description": "The compute resources for the container.",

--- a/score-v1b1.json
+++ b/score-v1b1.json
@@ -322,7 +322,18 @@
             {
               "type": "object",
               "additionalProperties": {
-                "$ref": "#/$defs/containerFile"
+                "allOf": [
+                  {
+                    "not": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "required": ["target"]
+                    }
+                  },
+                  {
+                    "$ref": "#/$defs/containerFile"
+                  }
+                ]
               }
             }
           ]
@@ -340,7 +351,18 @@
             {
               "type": "object",
               "additionalProperties": {
-                "$ref": "#/$defs/containerVolume"
+                "allOf": [
+                  {
+                    "not": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "required": ["target"]
+                    }
+                  },
+                  {
+                    "$ref": "#/$defs/containerVolume"
+                  }
+                ]
               }
             }
           ]


### PR DESCRIPTION
This implements the feature #121 to support maps of files and objects.

This is done with two changes:

1. Move file/volume object to an entry in the `#defs` section and remove required target field.
2. Use "oneOf" variants to support both map and arrays.

