### PR TITLE
Update permissions in workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,9 @@ on:
     branches: main
   pull_request: {}
 
+permissions:
+  contents: read
+
 jobs:
   linkchecker:
     runs-on: ubuntu-latest
@@ -14,8 +17,7 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@a8c4c7cb88f0c7386610c35eb25108e448569cb0 # v2.7.0
         with:
-          # Providing default parameters plus an exclude for Google Meet which produces a network error when checked
-          args: --verbose --no-progress './**/*.md' './**/*.html' --exclude https://meet.google.com
+          args: --verbose --no-progress './**/*.md' './**/*.html'
           fail: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -1,11 +1,13 @@
 name: Dependabot auto-merge
 on: pull_request
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 jobs:
   dependabot-auto-merge:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     if: ${{ github.actor == 'dependabot[bot]' && !github.event.pull_request.auto_merge }}
     steps:
       - name: Approve a PR

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,10 +3,12 @@ on:
   release:
     types: [published]
 permissions:
-  contents: write
+  contents: read
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Release


### PR DESCRIPTION
Update permissions in workflows also remove the gMeet link exception that we are not using anymore since this https://github.com/score-spec/spec/pull/173.