### PR TITLE
fix: refactor `before` field from array to per-container mapping

### DIFF
--- a/score-v1b1.json
+++ b/score-v1b1.json
@@ -368,26 +368,20 @@
           ]
         },
         "before": {
-          "description": "A list of containers which should run before a main process.",
-          "type": "array",
-          "additionalProperties": false,
-          "required": ["containers", "ready"],
-          "items": {
+          "description": "Defines before which other containers this container should be started.",
+          "type": "object",
+          "propertyNames": {
+            "minLength": 2,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$"
+          },
+          "additionalProperties": {
             "type": "object",
+            "required": ["ready"],
+            "additionalProperties": false,
             "properties": {
-              "containers": {
-                "description": "The list of containers to run before the main process.",
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "description": "A container ID in this implementation.",
-                  "minLength": 2,
-                  "maxLength": 63,
-                  "pattern": "^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$"
-                }
-              },
               "ready": {
-                "description": "The status of the container before the next container are started.",
+                "description": "The status of the container before the next containers are started.",
                 "title": "Ready",
                 "type": "string",
                 "enum": [

--- a/score-v1b1.json
+++ b/score-v1b1.json
@@ -368,7 +368,7 @@
           ]
         },
         "before": {
-          "description": "Defines before which other containers this container should be started.",
+          "description": "Containers which should be started before this container.",
           "type": "object",
           "propertyNames": {
             "minLength": 2,
@@ -381,7 +381,7 @@
             "additionalProperties": false,
             "properties": {
               "ready": {
-                "description": "The status of the container before the next containers are started.",
+                "description": "The status of the container before the next container is started.",
                 "title": "Ready",
                 "type": "string",
                 "enum": [


### PR DESCRIPTION
#### Description
Following the merge of #136, I noticed a couple of issues while going through the schema.
The `additionalProperties: false` and `required: ["containers", "ready"]` are sitting at the array level right now, but these only work on objects in JSON Schema validators will just ignore them there, so none of that validation was actually kicking in.
Also, as @chris-stephenson pointed out in the PR comments, the array approach implies ordering which we don't really care about here. Agreeing with his suggestion, this switches to a per-container mapping instead, which is a lot cleaner and easier to reason about.

#### What does this PR do?
- Switches `before` from an array to an object where each key is a container name
- Moves `required` and `additionalProperties` to the right place so validation actually works
- Fixes a small grammar issue in the description ("next container are" → "next containers are")
Example of how it looks now:

```
containers:
  init-one:
    image: busybox
    before:
      main:
        ready: complete
  main:
    image: myapp

```
#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

#### Checklist:
- [x] I've signed off with an email address that matches the commit author.
