### PR TITLE
fix: require at least one digit in CPU resource limit pattern

### DIFF
--- a/score-v1b1.json
+++ b/score-v1b1.json
@@ -189,7 +189,7 @@
         "cpu": {
           "description": "The CPU limit as whole or fractional CPUs. 'm' indicates milli-CPUs. For example 2 or 125m.",
           "type": "string",
-          "pattern": "^\\d*(?:m|\\.\\d+)?$"
+          "pattern": "^\\d+(?:m|\\.\\d+)?$"
         }
       }
     },


### PR DESCRIPTION
#### Description
The `cpu` field regex pattern under `resourcesLimits` currently uses `\d*` which matches zero or more digits. This means an empty string `""` or just `"m"` passes validation, which shouldn't be valid CPU values.

##### What does this PR do?
Changes `\d*` to `\d+` in the cpu pattern so at least one digit is required before the optional `m` suffix or decimal part.

Fixes #187

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

#### Checklist:
- [x] I've signed off with an email address that matches the commit author.
