### PR TITLE
fix: require at least one probe type in containerProbe definition

### DIFF
--- a/score-v1b1.json
+++ b/score-v1b1.json
@@ -429,7 +429,11 @@
         "exec": {
           "$ref": "#/$defs/execProbe"
         }
-      }
+      },
+      "anyOf": [
+        {"required": ["httpGet"]},
+        {"required": ["exec"]}
+      ]
     },
     "execProbe": {
       "description": "An executable health probe.",

--- a/score-v1b1.json
+++ b/score-v1b1.json
@@ -420,7 +420,7 @@
     },
     "containerProbe": {
       "type": "object",
-      "description": "The probe may be defined as either http, command execution, or both. The execProbe should be preferred if the Score implementation supports both types.",
+      "description": "The probe definition. At least one of 'httpGet' or 'exec' must be specified. The execProbe should be preferred if the Score implementation supports both types.",
       "additionalProperties": false,
       "properties": {
         "httpGet": {


### PR DESCRIPTION
#### Description
The `containerProbe` definition currently accepts an empty object `{}` as a valid probe since there's no constraint requiring at least one of `httpGet` or `exec`. An empty probe doesn't do anything useful and should be caught by validation.

##### What does this PR do?
Adds an `anyOf` constraint to the `containerProbe` definition so at least one probe type (`httpGet` or `exec`) must be specified. This prevents meaningless empty probes from passing schema validation.

Fixes #189

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

#### Checklist:
- [x] I've signed off with an email address that matches the commit author.
