### PR TITLE
fix: align memory regex with Kubernetes quantity grammar

### DIFF
--- a/score-v1b1.json
+++ b/score-v1b1.json
@@ -182,9 +182,9 @@
       "additionalProperties": false,
       "properties": {
         "memory": {
-          "description": "The memory limit in bytes with optional unit specifier. For example 125M or 1Gi.",
+          "description": "The memory limit in bytes with optional unit specifier. For example 125M or 1.5Gi.",
           "type": "string",
-          "pattern": "^[1-9]\\d*(K|M|G|T|Ki|Mi|Gi|Ti)?$"
+          "pattern": "^(0\\.\\d+|[1-9]\\d*(\\.\\d+)?)(K|M|G|T|P|E|Ki|Mi|Gi|Ti|Pi|Ei)?$"
         },
         "cpu": {
           "description": "The CPU limit as whole or fractional CPUs. 'm' indicates milli-CPUs. For example 2 or 125m.",


### PR DESCRIPTION
#### Description
Updates the `resourcesLimits.memory` pattern in `score-v1b1.json` so it accepts the memory values Kubernetes already accepts.

Today the pattern rejects `1.5Gi`, `0.5G`, `2.5M`, `1Pi`, and `2Ei` even though `kubectl apply` takes all of them without complaint. After this change those values validate. Bare lowercase `m` (milli) and Compose-style lowercase suffixes like `mb`, `gb`, `kb` stay rejected, since silently treating them as megabytes would be a footgun.

Old pattern: `^[1-9]\d*(K|M|G|T|Ki|Mi|Gi|Ti)?$`
New pattern: `^(0\.\d+|[1-9]\d*(\.\d+)?)(K|M|G|T|P|E|Ki|Mi|Gi|Ti|Pi|Ei)?$`

I also tweaked the description's example from `1Gi` to `1.5Gi` so the new decimal behavior is visible in the schema itself.

#### What does this PR do?
Closes #195.

The current regex is stricter than Kubernetes for no useful reason: it disallows decimals and stops at `T/Ti` while K8s goes up to `E/Ei`. People hit this when porting existing Kubernetes manifests into a `score.yaml`. A value their cluster has happily accepted for a year suddenly fails schema validation, with no real workaround beyond rounding to an integer.

One thing intentionally not in this PR: bare `0` is still rejected. `requests: 0` is meaningful in K8s ("no reservation") but `limits: 0` is not, and the two fields currently share this pattern. Splitting them is a structural change rather than a regex tweak, so it's getting its own follow-up issue.

Verified with `make test` (schema still valid, both sample files still pass) and manually against the comparison table from the issue body.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

The change is strictly more permissive: every value the old regex accepted is still accepted.

#### Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've signed off with an email address that matches the commit author.